### PR TITLE
Add ERC-4906 metadata update events

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ function initialize(
 ```
 
 Here, `notSoSecret` is `SomethingSomethingNoGrief`.
+
+## Metadata Update Events
+
+This repository implements the [ERC-4906](https://eips.ethereum.org/EIPS/eip-4906)
+standard. The contracts emit `MetadataUpdate` or `BatchMetadataUpdate` whenever
+an NFT's metadata changes (e.g. reveal, reroll or base URI updates).

--- a/src/Sheepy404.sol
+++ b/src/Sheepy404.sol
@@ -6,10 +6,9 @@ import {DN404} from "dn404/src/DN404.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {LibBitmap} from "solady/utils/LibBitmap.sol";
 import {DynamicArrayLib} from "solady/utils/DynamicArrayLib.sol";
-import {IERC4906} from "./interfaces/IERC4906.sol";
 
 /// @dev This contract can be used by itself or as an proxy's implementation.
-contract Sheepy404 is DN404, SheepyBase, IERC4906 {
+contract Sheepy404 is DN404, SheepyBase {
     using LibBitmap for *;
     using DynamicArrayLib for *;
 
@@ -103,7 +102,7 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             _revealed.set(id);
             emit Reveal(id);
-            emit MetadataUpdate(id);
+            _logMetadataUpdate(id);
         }
     }
 
@@ -123,7 +122,7 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
             uint256 id = tokenIds.get(i);
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             emit Reroll(id);
-            emit MetadataUpdate(id);
+            _logMetadataUpdate(id);
         }
     }
 
@@ -145,7 +144,7 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             _revealed.set(id);
             emit Reveal(id);
-            emit MetadataUpdate(id);
+            _logMetadataUpdate(id);
         }
     }
 
@@ -167,7 +166,7 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
             uint256 id = tokenIds.get(i);
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             emit Reroll(id);
-            emit MetadataUpdate(id);
+            _logMetadataUpdate(id);
         }
     }
 
@@ -197,7 +196,7 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
     /// @dev Sets the base URI.
     function setBaseURI(string memory newBaseURI) public virtual onlyOwnerOrRole(ADMIN_ROLE) {
         _baseURI = newBaseURI;
-        emit BatchMetadataUpdate(1, totalSupply() / _unit());
+        _logBatchMetadataUpdate(1, totalSupply() / _unit());
     }
 
     /// @dev Sets the reveal price.
@@ -254,7 +253,7 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
                     uint256 id = ids.get(i);
                     _revealed.unset(id);
                     emit Reset(id);
-                    emit MetadataUpdate(id);
+                    _logMetadataUpdate(id);
                 }
             }
         }
@@ -265,15 +264,26 @@ contract Sheepy404 is DN404, SheepyBase, IERC4906 {
         return true;
     }
 
-    /// @inheritdoc DN404
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        return interfaceId == type(IERC4906).interfaceId
-            || super.supportsInterface(interfaceId);
+    /// @dev Helper function to log metadata update to the mirror
+    function _logMetadataUpdate(uint256 tokenId) internal {
+        address mirror = _getDN404Storage().mirrorERC721;
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, 0x9e1569c7) // logMetadataUpdate(uint256)
+            mstore(0x20, tokenId)
+            pop(call(gas(), mirror, 0, 0x1c, 0x24, 0x00, 0x20))
+        }
+    }
+
+    /// @dev Helper function to log batch metadata update to the mirror
+    function _logBatchMetadataUpdate(uint256 fromTokenId, uint256 toTokenId) internal {
+        address mirror = _getDN404Storage().mirrorERC721;
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, 0x5f3058f7) // logBatchMetadataUpdate(uint256,uint256)
+            mstore(0x20, fromTokenId)
+            mstore(0x40, toTokenId)
+            pop(call(gas(), mirror, 0, 0x1c, 0x44, 0x00, 0x20))
+        }
     }
 }

--- a/src/Sheepy404.sol
+++ b/src/Sheepy404.sol
@@ -6,9 +6,10 @@ import {DN404} from "dn404/src/DN404.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {LibBitmap} from "solady/utils/LibBitmap.sol";
 import {DynamicArrayLib} from "solady/utils/DynamicArrayLib.sol";
+import {IERC4906} from "./interfaces/IERC4906.sol";
 
 /// @dev This contract can be used by itself or as an proxy's implementation.
-contract Sheepy404 is DN404, SheepyBase {
+contract Sheepy404 is DN404, SheepyBase, IERC4906 {
     using LibBitmap for *;
     using DynamicArrayLib for *;
 
@@ -102,6 +103,7 @@ contract Sheepy404 is DN404, SheepyBase {
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             _revealed.set(id);
             emit Reveal(id);
+            emit MetadataUpdate(id);
         }
     }
 
@@ -121,6 +123,7 @@ contract Sheepy404 is DN404, SheepyBase {
             uint256 id = tokenIds.get(i);
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             emit Reroll(id);
+            emit MetadataUpdate(id);
         }
     }
 
@@ -142,6 +145,7 @@ contract Sheepy404 is DN404, SheepyBase {
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             _revealed.set(id);
             emit Reveal(id);
+            emit MetadataUpdate(id);
         }
     }
 
@@ -163,6 +167,7 @@ contract Sheepy404 is DN404, SheepyBase {
             uint256 id = tokenIds.get(i);
             require(_callerIsAuthorizedFor(id), "Unauthorized.");
             emit Reroll(id);
+            emit MetadataUpdate(id);
         }
     }
 
@@ -192,6 +197,7 @@ contract Sheepy404 is DN404, SheepyBase {
     /// @dev Sets the base URI.
     function setBaseURI(string memory newBaseURI) public virtual onlyOwnerOrRole(ADMIN_ROLE) {
         _baseURI = newBaseURI;
+        emit BatchMetadataUpdate(1, totalSupply() / _unit());
     }
 
     /// @dev Sets the reveal price.
@@ -248,6 +254,7 @@ contract Sheepy404 is DN404, SheepyBase {
                     uint256 id = ids.get(i);
                     _revealed.unset(id);
                     emit Reset(id);
+                    emit MetadataUpdate(id);
                 }
             }
         }
@@ -256,5 +263,17 @@ contract Sheepy404 is DN404, SheepyBase {
     /// @dev Need to override this.
     function _useAfterNFTTransfers() internal virtual override returns (bool) {
         return true;
+    }
+
+    /// @inheritdoc DN404
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return interfaceId == type(IERC4906).interfaceId
+            || super.supportsInterface(interfaceId);
     }
 }

--- a/src/Sheepy404Mirror.sol
+++ b/src/Sheepy404Mirror.sol
@@ -2,12 +2,25 @@
 pragma solidity ^0.8.4;
 
 import {DN404Mirror} from "dn404/src/DN404Mirror.sol";
+import {IERC4906} from "./interfaces/IERC4906.sol";
 
 /// @dev This contract can be used by itself or as an proxy's implementation.
-contract Sheepy404Mirror is DN404Mirror {
+contract Sheepy404Mirror is DN404Mirror, IERC4906 {
     /*«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-«-*/
     /*                        CONSTRUCTOR                         */
     /*-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»-»*/
 
     constructor() DN404Mirror(msg.sender) {}
+
+    /// @inheritdoc DN404Mirror
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return interfaceId == type(IERC4906).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
 }

--- a/src/Sheepy404Mirror.sol
+++ b/src/Sheepy404Mirror.sol
@@ -13,14 +13,52 @@ contract Sheepy404Mirror is DN404Mirror, IERC4906 {
     constructor() DN404Mirror(msg.sender) {}
 
     /// @inheritdoc DN404Mirror
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override
-        returns (bool)
-    {
-        return interfaceId == type(IERC4906).interfaceId
-            || super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        // ERC-4906 interface ID is hardcoded in the EIP
+        return interfaceId == 0x49064906 || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Fallback function for calls from base DN404 contract.
+    fallback() external payable virtual override dn404NFTFallback {
+        uint256 fnSelector = __calldataload(0x00) >> 224;
+
+        // logMetadataUpdate(uint256)
+        if (fnSelector == 0x9e1569c7) {
+            if (msg.sender != baseERC20()) revert SenderNotBase();
+            emit MetadataUpdate(__calldataload(0x04));
+            assembly {
+                mstore(0x00, 0x01)
+                return(0x00, 0x20)
+            }
+        }
+
+        // logBatchMetadataUpdate(uint256,uint256)
+        if (fnSelector == 0x5f3058f7) {
+            if (msg.sender != baseERC20()) revert SenderNotBase();
+            emit BatchMetadataUpdate(__calldataload(0x04), __calldataload(0x24));
+            assembly {
+                mstore(0x00, 0x01)
+                return(0x00, 0x20)
+            }
+        }
+
+        __rv(uint32(FnSelectorNotRecognized.selector));
+    }
+
+    /// @dev Returns the calldata value at `offset`.
+    function __calldataload(uint256 offset) private pure returns (uint256 value) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            value := calldataload(offset)
+        }
+    }
+
+    /// @dev More bytecode-efficient way to revert.
+    function __rv(uint32 s) private pure {
+        /// @solidity memory-safe-assembly
+        assembly {
+            mstore(0x00, s)
+            revert(0x1c, 0x04)
+        }
     }
 }

--- a/src/interfaces/IERC4906.sol
+++ b/src/interfaces/IERC4906.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @title ERC-4906 Metadata Update Extension
+/// @dev Interface for emitting events when token metadata is changed.
+interface IERC4906 {
+    /// @dev Emitted when the metadata of a token is changed.
+    event MetadataUpdate(uint256 _tokenId);
+
+    /// @dev Emitted when the metadata of a range of tokens is changed.
+    event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId);
+}


### PR DESCRIPTION
## Summary
- add `IERC4906` interface
- emit `MetadataUpdate` and `BatchMetadataUpdate` in Sheepy404
- advertise ERC-4906 usage in README
- expose ERC-4906 support from Sheepy404Mirror

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`